### PR TITLE
[FIX]Work Orders not able to add new lines

### DIFF
--- a/mrp_account_analytic_wip/views/mrp_production_views.xml
+++ b/mrp_account_analytic_wip/views/mrp_production_views.xml
@@ -54,7 +54,7 @@
             </xpath>
 
             <xpath expr="//page[@name='operations']/field[@name='workorder_ids']" position="replace">
-                <field name="workorder_ids" attrs="{'readonly': ['|', '|', ('state', '=', 'cancel'), ('state', '=', 'progress'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'default_product_uom_id': product_uom_id, 'from_manufacturing_order': True}"/>
+                <field name="workorder_ids" attrs="{'readonly': ['|', '|', ('state', '=', 'cancel'), ('state', '=', 'done'), '&amp;', ('state', '=', 'done'), ('is_locked', '=', True)]}" context="{'tree_view_ref': 'mrp.mrp_production_workorder_tree_editable_view', 'default_product_uom_id': product_uom_id, 'from_manufacturing_order': True}"/>
             </xpath>
 
         </field>


### PR DESCRIPTION
Able to add new lines in the progress state. Changed read only filter to done and cancel instead of done and progress

Ticket: https://pm.opensourceintegrators.com/web#id=36680&cids=1&model=helpdesk.ticket&view_type=form